### PR TITLE
Make #legal deep link reliably scroll and expand

### DIFF
--- a/src/components/Legal.tsx
+++ b/src/components/Legal.tsx
@@ -1,23 +1,16 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useMemo, useState } from "react";
 import Collapsed from "./Collapsed";
 import Comment from "./Comment";
 import CommentBlock from "./CommentBlock";
 
-const openOnStart = window.location.hash === "#legal";
+// Auto-expand when deep-linked via tamino.dev/#legal. The scroll itself is
+// handled by App's shared deep-link logic, which keys off `data-entry`.
+const openOnStart = decodeURIComponent(window.location.hash.slice(1)) === "legal";
 
 export default function Legal() {
   const [collapsed, setCollapsed] = useState(!openOnStart);
-  const ref = useRef<HTMLDivElement>(null);
 
   const year = useMemo(() => new Date().getFullYear(), []);
-
-  useEffect(() => {
-    if (openOnStart && ref.current) {
-      setTimeout(() => {
-        window.scrollTo({ top: ref.current?.offsetTop });
-      }, 1750);
-    }
-  }, []);
 
   const toggle = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -25,7 +18,7 @@ export default function Legal() {
   };
 
   return (
-    <div ref={ref} className={`legal${collapsed ? " collapsed" : ""}`} onClick={toggle}>
+    <div className={`legal${collapsed ? " collapsed" : ""}`} data-entry="legal" onClick={toggle}>
       {collapsed ? (
         <Comment comment={`(c) ${year} Tamino Martinius`}>
           <Collapsed />


### PR DESCRIPTION
## Summary

Visiting `tamino.dev/#legal` now reliably scrolls to the legal section and auto-expands it.

## Problem

`Legal.tsx` already tried to handle `#legal`, but it was unreliable. The loader keeps `#root` at `display:none` until the body gets the `step-7` class at `7 × 250 + random` ≈ 1750–1800ms. The old code fired `window.scrollTo` at a **hardcoded 1750ms** — racing that reveal and usually losing, so `offsetTop` was measured as `0` while still hidden and the page just scrolled to the top. It also used an instant `scrollTo` that fought `App.tsx`'s animated deep-link scroll.

## Fix

Opt Legal into the deep-link mechanism `App.tsx` already uses for every other item:

- Add `data-entry="legal"` to Legal's root — the same pattern `Stage` items use, so `App.tsx` picks it up automatically (waits for the loader animation, then smoothly animates the scroll). No change needed in `App.tsx`.
- Remove the brittle `useRef` + `setTimeout(1750)` + `window.scrollTo` block.
- Keep `openOnStart` for auto-expand, aligning its hash parsing with the rest of the codebase (`decodeURIComponent(hash.slice(1))`).

## Verification

- `typecheck`, `lint`, and `build` all pass (the CI gates).
- Browser-tested with Playwright:
  - `/#legal` → scrolled to Legal (`scrollY === maxScroll`), expanded showing the full address, and the `#legal` hash stays in the URL.
  - `/` (no hash) → loads at the top with Legal collapsed (no regression).